### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install git+https://github.com/pnnl-predictive-phenomics/eflux.git
 
 ## License
 
-The code in this package is licensed under the GPLv2 License.
+The code in this package is licensed under the BSD-2 License.
 
 
 ## Development


### PR DESCRIPTION
for E-flux, GitHub read me file states, "The code in this package is licensed under the GPLv2 License". However, the license tab provides the "BSD 2-Clause License".